### PR TITLE
README: include configuration setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,92 @@
 # README #
 
-At the minute, the only way to install the ```cardano-node``` and the ```cardano-cli```, necessary to run a stake pool on Shelley, is to compile them. Compilation can be troublesome for some and lead to issues. To reduce complexity and have predictable results, I use a Docker build environment. This setup will always to build against the latest ```cardano-node``` version and ```pioneer-*``` tag as in [the official documentation](https://github.com/input-output-hk/cardano-tutorials/blob/master/node-setup/build.md).
+Currently, the only way to install the ```cardano-node``` and the ```cardano-cli```, necessary to run a stake pool on Shelley, is to compile them. Compilation can be troublesome for some and lead to issues. To reduce complexity and have predictable results, this setup uses a Docker build environment. This setup will always build against the latest ```cardano-node``` version and ```pioneer-*``` tag as in [the official documentation](https://github.com/input-output-hk/cardano-tutorials/blob/master/node-setup/build.md).
 
 **IMPORTANT: you must run these steps to compile ```cardano-node``` and ```cardano-cli``` on your local computer, and copy them over to your servers. This is to avoid useless load and installing compilation software on your servers.**
 
-## install docker ##
+## Install docker ##
 
 Install and run Docker Desktop for your OS from [the official site](https://www.docker.com/products/docker-desktop), on your local computer.
 
-## clone the build repo ##
+## Clone the build repo ##
 
 ```bash
 git clone https://github.com/gacallea/cardanoNodeBuilder.git
 ```
 
-## compile the software ##
+## Compile the software ##
 
 ```bash
 cd cardanoNodeBuilder
 docker-compose up --build -d
 ```
 
-## copy the binaries to your host ##
+## Copy the binaries to your host ##
 
 ```bash
-docker container cp build_builder_1:/usr/local/bin cardano-bins/
+docker container cp build_builder_1:/usr/local/bin/* cardano-bins/
 ```
 
-## scp the binaries to your nodes ##
+## Test cardano-node locally 
+
+Follow below steps to test cardano-node testnet locally. Note, this setup is not expected for live mainnet setup. Follow steps on [Mainnet stake pool setup](#mainnet-stake-pool-setup)
+
+```
+cd cardano-bins
+```
+
+**Verify cardano-node & cardano-cli version**
+
+Verify cardano-node and cli ouput version: **1.18.0**
+
+```bash
+./bin/cardano-node --version
+```
+
+```bash
+./bin/cardano-cli --version
+```
+
+**Download configs**
+
+Download the [official cardano configurations](https://hydra.iohk.io/build/3627488/download/1/index.html) based on your desired cluster target. For this setup we will use `testnet` configs
+
+```
+wget https://hydra.iohk.io/build/3627488/download/1/testnet-config.json -P configs
+wget https://hydra.iohk.io/build/3627488/download/1/testnet-byron-genesis.json -P configs
+wget https://hydra.iohk.io/build/3627488/download/1/testnet-shelley-genesis.json -P configs
+wget https://hydra.iohk.io/build/3627488/download/1/testnet-topology.json -P configs
+```
+
+
+### Optionally - tweak config 
+
+If you prefer graphical interface, You can update the `configs/testnet-config.json` `ViewMode` config to `LiveView` 
+
+
+### Create db and socket files
+
+The `db` is to store the blockchain information and `socket` for node socket.
+
+```
+mkdir -p db socket
+```
+
+### Run node
+
+Start node on port **3000** with the downloaded testnet configs.
+
+
+```
+./bin/cardano-node run --database-path ./db/core/ --socket-path ./socket/core --port 3000 --config configs/testnet-config.json  --topology configs/testnet-topology.json
+```
+
+If everything went right you should see node starts syncing.
+
+
+## Mainnet stake pool setup
+
+### Copy the binaries to your nodes ##
 
 **NOTE: Make sure you point to your actual servers.**
 
@@ -40,3 +99,7 @@ scp cardano-bins/bin/cardano-cli node-server:/usr/local/bin/
 scp cardano-bins/bin/cardano-node relay-server:/usr/local/bin/
 scp cardano-bins/bin/cardano-cli relay-server:/usr/local/bin/
 ```
+
+### Configure nodes
+
+You can follow [this setup instructions](https://cardano-node-installation.stakepool247.eu/cardano-node-configuration/cardano-node-configuration) to configure nodes properly for live mainnet nodes stake pool operation.


### PR DESCRIPTION
Hi,

I found the docker setup really useful. I have tweaked the README to include a bit more information on how to test and run nodes so it helps users with less experienced or familiarly with cardano nodes get started quicker.

PR includes:
- Small wording tweaks
- Steps to run sample node locally, just for demonstration purposes. 
- External link to mainnet nodes configuration from [this](https://cardano-node-installation.stakepool247.eu/cardano-node-configuration/cardano-node-configuration) stakepool operator which I also found to be helpful. 

Thanks!